### PR TITLE
修复-对于不支持的数据验证格式，跳过处理

### DIFF
--- a/src/ToLuckySheet/LuckySheet.ts
+++ b/src/ToLuckySheet/LuckySheet.ts
@@ -581,6 +581,9 @@ export class LuckySheet extends LuckySheetBase {
         let formulaValue = row.value;
   
         let type = getXmlAttibute(attrList, "type", null);
+        if(!type) {
+            continue;
+        }
         let operator = "",
             sqref = "",
             sqrefIndexArr: string[] = [],


### PR DESCRIPTION
时间格式的数据验证不支持，导致转换报错。暂时做跳过处理。